### PR TITLE
Remove apiURL as an option

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -1,2 +1,1 @@
-API_URL=http://dataservice.accuweather.com
 ACCESS_TOKEN=QeBDBAoZneiKDUGi1DHMqf4hnDn7tGN9

--- a/src/main.js
+++ b/src/main.js
@@ -1,4 +1,5 @@
 import dotenv from 'dotenv'
+import { apiURL } from './config'
 
 import location from './location'
 import weather from './weather'
@@ -7,7 +8,7 @@ dotenv.config()
 
 export default class AccuWeatherWrapper {
   constructor (options) {
-    this.apiURL = options.apiURL || process.env.API_URL
+    this.apiURL = apiURL
     this.token = options.token || process.env.ACCESS_TOKEN
 
     this.getLocation = location.bind(this)()

--- a/tests/main.spec.js
+++ b/tests/main.spec.js
@@ -14,15 +14,7 @@ describe('AccuWeatherWrapper Library', () => {
     expect(accuweather).to.be.an.instanceOf(AccuWeatherWrapper)
   })
 
-  it('should receive apiURL as an option', () => {
-    const accuweather = new AccuWeatherWrapper({
-      apiURL: 'http://api-url.com'
-    })
-
-    expect(accuweather.apiURL).to.be.equal('http://api-url.com')
-  })
-
-  it('should use the default apiURL if not provided', () => {
+  it('should have a default apiURL', () => {
     const accuweather = new AccuWeatherWrapper({})
 
     expect(accuweather.apiURL).to.be.equal('http://dataservice.accuweather.com')


### PR DESCRIPTION
The API URL should be always the same, so I decided to remove it as an option.